### PR TITLE
feat : 차량 조회 서비스 수정

### DIFF
--- a/src/main/java/com/flab/simplesharingcar/constants/CarReservationStatus.java
+++ b/src/main/java/com/flab/simplesharingcar/constants/CarReservationStatus.java
@@ -1,5 +1,0 @@
-package com.flab.simplesharingcar.constants;
-
-public enum CarReservationStatus {
-    DISABLED, WAITING, RESERVED, DRIVING, DELAY_RETURN
-}

--- a/src/main/java/com/flab/simplesharingcar/constants/CarStatus.java
+++ b/src/main/java/com/flab/simplesharingcar/constants/CarStatus.java
@@ -1,0 +1,5 @@
+package com.flab.simplesharingcar.constants;
+
+public enum CarStatus {
+    DISABLED, ENABLED, NOT_RESERVATION
+}

--- a/src/main/java/com/flab/simplesharingcar/constants/ReservationStatus.java
+++ b/src/main/java/com/flab/simplesharingcar/constants/ReservationStatus.java
@@ -1,0 +1,5 @@
+package com.flab.simplesharingcar.constants;
+
+public enum ReservationStatus {
+    WAITING, RESERVED, DRIVING, DELAY_RETURN
+}

--- a/src/main/java/com/flab/simplesharingcar/domain/Reservation.java
+++ b/src/main/java/com/flab/simplesharingcar/domain/Reservation.java
@@ -1,6 +1,6 @@
 package com.flab.simplesharingcar.domain;
 
-import com.flab.simplesharingcar.constants.CarReservationStatus;
+import com.flab.simplesharingcar.constants.ReservationStatus;
 import java.time.LocalDateTime;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -42,6 +42,6 @@ public class Reservation {
     private LocalDateTime resEndTime;
 
     @Enumerated(EnumType.STRING)
-    private CarReservationStatus status;
+    private ReservationStatus status;
 
 }

--- a/src/main/java/com/flab/simplesharingcar/domain/SharingCar.java
+++ b/src/main/java/com/flab/simplesharingcar/domain/SharingCar.java
@@ -1,7 +1,6 @@
 package com.flab.simplesharingcar.domain;
 
-import com.flab.simplesharingcar.constants.CarReservationStatus;
-import java.time.LocalDateTime;
+import com.flab.simplesharingcar.constants.CarStatus;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Entity;
@@ -15,7 +14,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -40,51 +38,6 @@ public class SharingCar {
     private List<Reservation> reservations = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
-    private CarReservationStatus status;
+    private CarStatus status;
 
-    @Builder
-    public SharingCar(Long id, SharingZone sharingZone, StandardCar standardCar,
-        List<Reservation> reservations, CarReservationStatus status) {
-        this.id = id;
-        this.sharingZone = sharingZone;
-        this.standardCar = standardCar;
-        this.reservations = reservations;
-        this.status = status;
-    }
-
-    public static SharingCar newInstanceByTime(SharingCar from, LocalDateTime time) {
-        Long id = from.getId();
-        SharingZone sharingZone = from.getSharingZone();
-        StandardCar standardCar = from.getStandardCar();
-        List<Reservation> reservations = from.getReservations();
-        CarReservationStatus status = from.getReservationStatus(time);
-
-        SharingCar result = SharingCar.builder()
-            .id(id)
-            .sharingZone(sharingZone)
-            .standardCar(standardCar)
-            .reservations(reservations)
-            .status(status)
-            .build();
-        return result;
-    }
-
-    private CarReservationStatus getReservationStatus(LocalDateTime searchTime) {
-        if (reservations.size() == 0) {
-            return status;
-        }
-
-        CarReservationStatus result = reservations.stream()
-            .filter((reservation) -> {
-                LocalDateTime resStartTime = reservation.getResStartTime();
-                LocalDateTime resEndTime = reservation.getResEndTime();
-
-                return searchTime.compareTo(resStartTime) > -1
-                    && searchTime.isBefore(resEndTime);
-            })
-            .map(Reservation::getStatus)
-            .findFirst()
-            .orElse(status);
-        return result;
-    }
 }

--- a/src/main/java/com/flab/simplesharingcar/repository/SharingCarRepositorySupport.java
+++ b/src/main/java/com/flab/simplesharingcar/repository/SharingCarRepositorySupport.java
@@ -6,5 +6,6 @@ import java.util.List;
 
 public interface SharingCarRepositorySupport {
 
-    List<SharingCar> findReservatableCar(Long sharingZoneId, LocalDateTime resStartTime);
+    List<SharingCar> findReserveCars(Long sharingZoneId, LocalDateTime startTime
+        , LocalDateTime endTime);
 }

--- a/src/main/java/com/flab/simplesharingcar/service/sharing/SharingCarService.java
+++ b/src/main/java/com/flab/simplesharingcar/service/sharing/SharingCarService.java
@@ -14,13 +14,12 @@ public class SharingCarService {
 
     private final SharingCarRepository sharingCarRepository;
 
-    public List<SharingCar> findByZoneIdAndTime(Long sharingZoneId, LocalDateTime searchTime) {
-        List<SharingCar> sharingCarList = sharingCarRepository.findReservatableCar(
-            sharingZoneId, searchTime);
+    public List<SharingCar> findByZoneIdAndTime(Long sharingZoneId, LocalDateTime startTime,
+        LocalDateTime endTime) {
 
-        List<SharingCar> resultList = sharingCarList.stream()
-            .map(sharingCar -> SharingCar.newInstanceByTime(sharingCar, searchTime))
-            .collect(Collectors.toList());
-        return resultList;
+        List<SharingCar> sharingCarList = sharingCarRepository.findReserveCars(
+            sharingZoneId, startTime, endTime);
+
+        return sharingCarList;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,6 @@ spring:
         max-active: 8
     port: 6379
     host: localhost
+logging:
+  level:
+    org.hibernate.type: trace

--- a/src/main/resources/db/mysql/data.sql
+++ b/src/main/resources/db/mysql/data.sql
@@ -78,12 +78,12 @@ FROM (
 
          SELECT 1 AS standard_car_id
               , 1 AS sharing_zone_id
-              , 'WAITING' AS status
+              , 'ENABLED' AS status
          FROM DUAL
          UNION ALL
          SELECT 1 AS standard_car_id
               , 2 AS sharing_zone_id
-              , 'WAITING' AS status
+              , 'ENABLED' AS status
          FROM DUAL
          UNION ALL
          SELECT 2 AS standard_car_id
@@ -93,27 +93,27 @@ FROM (
          UNION ALL
          SELECT 2 AS standard_car_id
               , 2 AS sharing_zone_id
-              , 'WAITING' AS status
+              , 'ENABLED' AS status
          FROM DUAL
          UNION ALL
          SELECT 1 AS standard_car_id
               , 3 AS sharing_zone_id
-              , 'WAITING' AS status
+              , 'ENABLED' AS status
          FROM DUAL
          UNION ALL
          SELECT 2 AS standard_car_id
               , 3 AS sharing_zone_id
-              , 'WAITING' AS status
+              , 'ENABLED' AS status
          FROM DUAL
          UNION ALL
          SELECT 3 AS standard_car_id
               , 3 AS sharing_zone_id
-              , 'WAITING' AS status
+              , 'ENABLED' AS status
          FROM DUAL
          UNION ALL
          SELECT 4 AS standard_car_id
               , 3 AS sharing_zone_id
-              , 'WAITING' AS status
+              , 'ENABLED' AS status
          FROM DUAL
      ) A
 WHERE NOT EXISTS (
@@ -127,10 +127,10 @@ DELETE FROM reservation WHERE id = 2;
 DELETE FROM reservation WHERE id = 3;
 
 INSERT INTO reservation(id, sharing_car_id, res_start_time, res_end_time, status)
-VALUES(1, 1, date_add(now(), interval -1 day), date_add(now(), interval 1 day), 'RESERVED');
+VALUES(1, 1, date_add(now(), interval -1 hour), date_add(date_add(now(), interval 1 hour), interval -1 second), 'RESERVED');
 
 INSERT INTO reservation(id, sharing_car_id, res_start_time, res_end_time, status)
-VALUES(2, 1, date_add(now(), interval 1 day), date_add(now(), interval 2 day), 'RESERVED');
+VALUES(2, 1, date_add(now(), interval 1 hour), date_add(date_add(now(), interval 2 hour), interval -1 second), 'RESERVED');
 
 INSERT INTO reservation(id, sharing_car_id, res_start_time, res_end_time, status)
-VALUES(3, 2, date_add(now(), interval -1 day), date_add(now(), interval 1 day), 'RESERVED');
+VALUES(3, 2, date_add(now(), interval -1 hour), date_add(date_add(now(), interval 1 hour), interval -1 second), 'RESERVED');

--- a/src/test/java/com/flab/simplesharingcar/repository/SharingCarRepositoryTest.java
+++ b/src/test/java/com/flab/simplesharingcar/repository/SharingCarRepositoryTest.java
@@ -3,12 +3,13 @@ package com.flab.simplesharingcar.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.flab.simplesharingcar.config.QuerydslConfig;
-import com.flab.simplesharingcar.constants.CarReservationStatus;
 import com.flab.simplesharingcar.constants.CarType;
+import com.flab.simplesharingcar.constants.ReservationStatus;
 import com.flab.simplesharingcar.domain.Reservation;
 import com.flab.simplesharingcar.domain.SharingCar;
 import com.flab.simplesharingcar.domain.StandardCar;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,26 +38,26 @@ class SharingCarRepositoryTest {
         // given
         Long sharingZoneId = 1L;
         LocalDateTime now = LocalDateTime.now();
+        LocalDateTime to = now.plus(1, ChronoUnit.HOURS);
         // when
-        List<SharingCar> reservatableCar = sharingCarRepository.findReservatableCar(sharingZoneId,
-            now);
+        List<SharingCar> reservatableCar = sharingCarRepository.findReserveCars(sharingZoneId, now, to);
         // then
-        assertThat(reservatableCar).hasSize(1);
+        assertThat(reservatableCar).hasSize(2);
     }
 
     @Test
-    public void 차량_예약_상태_확인() {
+    public void 차량_예약_확인() {
         // given
         Long sharingZoneId = 1L;
         LocalDateTime now = LocalDateTime.now();
+        LocalDateTime to = now.plus(1, ChronoUnit.HOURS);
         // when
-        List<SharingCar> reservatableCar = sharingCarRepository.findReservatableCar(sharingZoneId,
-            now);
+        List<SharingCar> reservatableCar = sharingCarRepository.findReserveCars(sharingZoneId, now, to);
         // then
         SharingCar sharingCar = reservatableCar.get(0);
         Reservation reservation = sharingCar.getReservations().get(0);
-        CarReservationStatus status = reservation.getStatus();
-        assertThat(status).isEqualTo(CarReservationStatus.RESERVED);
+        ReservationStatus status = reservation.getStatus();
+        assertThat(status).isEqualTo(ReservationStatus.RESERVED);
     }
 
     @Test
@@ -64,11 +65,11 @@ class SharingCarRepositoryTest {
         // given
         Long sharingZoneId = 2L;
         LocalDateTime now = LocalDateTime.now();
+        LocalDateTime to = now.plus(1, ChronoUnit.HOURS);
         // when
-        List<SharingCar> reservatableCar = sharingCarRepository.findReservatableCar(sharingZoneId,
-            now);
+        List<SharingCar> reservatableCar = sharingCarRepository.findReserveCars(sharingZoneId, now, to);
         // then
-        // 2L -> RESERVED, 4L -> WAITING
+        // 2L -> NOT_RESERVATION, 4L -> ENABLED
         SharingCar sharingCar = reservatableCar.get(1);
         Long id = sharingCar.getId();
         assertThat(id).isEqualTo(2L);
@@ -79,9 +80,9 @@ class SharingCarRepositoryTest {
         // given
         Long sharingZoneId = 3L;
         LocalDateTime now = LocalDateTime.now();
+        LocalDateTime to = now.plus(1, ChronoUnit.HOURS);
         // when
-        List<SharingCar> reservatableCar = sharingCarRepository.findReservatableCar(sharingZoneId,
-            now);
+        List<SharingCar> reservatableCar = sharingCarRepository.findReserveCars(sharingZoneId, now, to);
         // then
         // 0 LIGHT_CAR, 1 SEMI_MIDSIZE_CAR, 2 MIDSIZE_CAR, 3 LARGE_CAR,
         SharingCar sharingCar = reservatableCar.get(1);


### PR DESCRIPTION
차량 조회 시 예약 정보 Fetch Join 제거(정렬에만 사용),
검색 조건 예약 종료 시간 추가,
차량 <-> 예약 상태 분리

기존에는 차량 조회 시 예약 정보를 한번에 들고 와서 예약 정보를 보여주려고 했는데.
이 부분을 따로 처리해야 할 것 같아서 분리 하였습니다.
